### PR TITLE
build: only run test actions when path changed

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -1,6 +1,8 @@
 name: Test Actions
 on:
   push:
+    paths: ['actions/**']
+
   schedule:
     - cron:  '0 * * * *'
 jobs:


### PR DESCRIPTION
These tests can take a good amount of time, should skip if not necessary.