### PR TITLE
fix: use different base file

### DIFF
--- a/actions/gapic/Dockerfile
+++ b/actions/gapic/Dockerfile
@@ -1,6 +1,5 @@
-FROM gcr.io/cloud-builders/bazel@sha256:7bd6d26119121e301f30366b5aafbbd0f4b3db9be5fd9da34db49df745e18e2b
-
-RUN apt-get update && apt-get install zip python2.7-dev -y
+FROM l.gcr.io/google/bazel:latest 
+# https://github.com/GoogleCloudPlatform/container-definitions/tree/master/ubuntu1604_bazel
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This should have the required environment for most bazel builds and be faster.