### PR TITLE
chore: Use googlemaps-bot repo token for sync files.

### DIFF
--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@a8d5c6efadcb601ab84a5fe68f1e9669f9c3a999
         with:
-          GH_PAT: ${{ secrets.JPOEHNELT }}
+          GH_PAT: ${{ secrets.GOOGLEMAPS_BOT_REPO_TOKEN }}
           COMMIT_PREFIX: "chore: "
           OVERWRITE_EXISTING_PR: true
           CONFIG_PATH: .github/sync-files.yml


### PR DESCRIPTION
Update access token to @googlemaps-bot for sync-files action.