### PR TITLE
chore: Unsync .releaserc across Java libs

### DIFF
--- a/.github/sync-files.yml
+++ b/.github/sync-files.yml
@@ -128,8 +128,6 @@ group:
   - files:
       - source: sync-files/java/.github/
         dest: .github/
-      - source: sync-files/java/.releaserc
-        dest: .releaserc
     repos: |
       googlemaps/google-maps-services-java
       googlemaps/java-fleetengine-auth


### PR DESCRIPTION
Unsyncing .releaserc since Java libs have different .releaserc
