### PR TITLE
revert: "chore: add secret sync for Android keys"

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,7 +20,6 @@ jobs:
         env:
           SYNCED_RUN_ID: ${{github.run_id}}
           SYNCED_GITHUB_TOKEN_REPO: ${{secrets.GOOGLEMAPS_BOT_REPO_TOKEN}}
-          SYNCED_GOOGLE_MAPS_API_KEY_ANDROID: ${{secrets.GOOGLE_MAPS_API_KEY_ANDROID}}
           SYNCED_GOOGLE_MAPS_API_KEY_SERVICES: ${{secrets.GOOGLE_MAPS_API_KEY_SERVICES}}
           SYNCED_GOOGLE_MAPS_API_KEY_WEB: ${{secrets.GOOGLE_MAPS_API_KEY_WEB}}
       - run: sleep 30s


### PR DESCRIPTION
Reverts googlemaps/.github#57

Using Organization secrets instead