### PR TITLE
chore: update android workflows centrally

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,2 @@
-assign_issues:
-  - wangela
-assign_prs:
-  - wangela
+assign_issues: []
+assign_prs: []

--- a/sync-files/android/.github/workflows/release.yml
+++ b/sync-files/android/.github/workflows/release.yml
@@ -45,15 +45,20 @@ jobs:
         GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
         SONATYPE_PASSWORD: ${{ secrets.SYNCED_SONATYPE_PASSWORD }}
         SONATYPE_USERNAME: ${{ secrets.SYNCED_SONATYPE_USERNAME }}
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
     - name: Semantic Release
-      uses: cycjimmy/semantic-release-action@v3
+      uses: cycjimmy/semantic-release-action@v3.4.1
       with:
         extra_plugins: |
-          "@semantic-release/commit-analyzer"
-          "@semantic-release/release-notes-generator"
+          "@semantic-release/commit-analyzer@8.0.1"
+          "@semantic-release/release-notes-generator@9.0.3"
           "@google/semantic-release-replace-plugin"
-          "@semantic-release/exec"
-          "@semantic-release/git
-          "@semantic-release/github
+          "@semantic-release/exec@5.0.0"
+          "@semantic-release/git@9.0.1"
+          "@semantic-release/github@7.2.3"
       env:
         GH_TOKEN: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}

--- a/sync-files/android/.github/workflows/test.yml
+++ b/sync-files/android/.github/workflows/test.yml
@@ -23,6 +23,7 @@ on:
   pull_request:
     branches-ignore: ['gh-pages']
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   test:

--- a/sync-files/android/.lib_releaserc_groovy
+++ b/sync-files/android/.lib_releaserc_groovy
@@ -11,7 +11,7 @@ plugins:
           to: "version = '${nextRelease.version}'"
         - files:
             - "README.md"
-          from: ":[0-9].[0-9].[0-9]"
+          from: ":([0-9]+).([0-9]+).([0-9]+)"
           to: ":${nextRelease.version}"
   - - "@semantic-release/exec"
     - prepareCmd: "./gradlew build --warn --stacktrace"

--- a/sync-files/android/.lib_releaserc_kts
+++ b/sync-files/android/.lib_releaserc_kts
@@ -11,7 +11,7 @@ plugins:
           to: "version = '${nextRelease.version}'"
         - files:
             - "README.md"
-          from: ":[0-9].[0-9].[0-9]"
+          from: ":([0-9]+).([0-9]+).([0-9]+)"
           to: ":${nextRelease.version}"
   - - "@semantic-release/exec"
     - prepareCmd: "./gradlew build --warn --stacktrace"

--- a/sync-files/android/.plugin_releaserc
+++ b/sync-files/android/.plugin_releaserc
@@ -11,7 +11,7 @@ plugins:
           to: "version = '${nextRelease.version}'"
         - files:
             - "README.md"
-          from: ":[0-9].[0-9].[0-9]"
+          from: ":([0-9]+).([0-9]+).([0-9]+)"
           to: ":${nextRelease.version}"
   - - "@semantic-release/exec"
     - prepareCmd: "./gradlew build --warn --stacktrace"


### PR DESCRIPTION
- Update blunderbuss to stop auto-assigning issues and PRs
- Android worklows
  - Pin semantic release and extra plugins to Node 14 versions
  - Allow test workflow calls from another workflow (dependabot)
  - Handle release updates for regex patterns with version numbers >1 digit
