### PR TITLE
chore: fix android semantic release replace plugin dependency

### DIFF
--- a/sync-files/android/.github/workflows/release.yml
+++ b/sync-files/android/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         extra_plugins: |
           "@semantic-release/commit-analyzer@8.0.1"
           "@semantic-release/release-notes-generator@9.0.3"
-          "@google/semantic-release-replace-plugin"
+          "@google/semantic-release-replace-plugin@1.2.0"
           "@semantic-release/exec@5.0.0"
           "@semantic-release/git@9.0.1"
           "@semantic-release/github@7.2.3"


### PR DESCRIPTION
Fix per https://github.com/cycjimmy/semantic-release-action/issues/169