### PR TITLE
fix: README links

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -89,11 +89,11 @@ External contributions are not accepted for this repository. See [contributing g
 
 This library uses Google Maps Platform services. Use of Google Maps Platform services through this library is subject to the Google Maps Platform [Terms of Service].
 
-This library is not a Google Maps Platform Core Service. Therefore, the Google Maps Platform Terms of Service (e.g. Technical Support Services, Service Level Agreements, and Deprecation Policy) do not apply to the code in this library.
+This library is not a Google Maps Platform Core Service. Therefore, the Google Maps Platform Terms of Service, e.g., [Technical Support Services Guidelines], Service Level Agreement ["SLA"][SLA], and [Deprecation Policy], do not apply to the code in this library.
 
 ## Support
 
-This library is offered via an open source [license]. It is not governed by the Google Maps Platform Support [Technical Support Services Guidelines, the SLA, or the [Deprecation Policy]. However, any Google Maps Platform services used by the library remain subject to the Google Maps Platform Terms of Service.
+This library is offered via an open source [license]. It is not governed by the Google Maps Platform Support Technical Support Services Guidelines, the SLA, or the Deprecation Policy. However, any Google Maps Platform services used by the library remain subject to the Google Maps Platform Terms of Service.
 
 This library adheres to [semantic versioning] to indicate when backwards-incompatible changes are introduced. Accordingly, while the library is in version 0.x, backwards-incompatible changes may be introduced at any time.
 
@@ -127,8 +127,8 @@ https://developers.google.com/maps/documentation/places/ios-sdk/config#get-an-ap
 [Discord server]: https://discord.gg/hYsWbmk
 [file an issue]: https://github.com/googlemaps/REPO/issues/new/choose
 [license]: LICENSE
-[pull request]: https://github.com/googlemaps/REPO/compare
 [project]: https://developers.google.com/maps/documentation/PRODUCT/cloud-setup#enabling-apis
+[pull request]: https://github.com/googlemaps/REPO/compare
 [semantic versioning]: https://semver.org
 [Sign up with Google Maps Platform]: https://console.cloud.google.com/google/maps-apis/start
 [similar inquiry]: https://github.com/googlemaps/REPO/issues


### PR DESCRIPTION
fix typo; missing right bracket "]" causes links to break